### PR TITLE
Fixed name collision with Constructor::ArgumentError

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require 'rubygems'
 require 'bundler/setup'
 Bundler::GemHelper.install_tasks
 begin
-  require 'rake/rdoctask'
+  require 'rdoc/task'
   require 'spec/rake/spectask'
 rescue
   puts "You need to: bundle install"
@@ -17,7 +17,7 @@ Spec::Rake::SpecTask.new(:spec) do |t|
 end
 
 desc 'Generate documentation'
-Rake::RDocTask.new(:rdoc) do |rdoc|
+RDoc::Task.new(:rdoc) do |rdoc|
   rdoc.rdoc_dir = 'doc'
   rdoc.title    = 'constructor'
   rdoc.options << '--line-numbers' << '--inline-source'

--- a/lib/constructor/constructor.rb
+++ b/lib/constructor/constructor.rb
@@ -7,7 +7,7 @@ module Constructor #:nodoc:#
     if config[:require_args]
       # First, make sure we've got args of some kind
       unless args and args.keys and args.keys.size > 0 
-        raise ArgumentError.new(keys)
+        raise ConstructorArgumentError.new(keys)
       end
       # Scan for missing keys in the argument hash
       a_keys = args.keys
@@ -19,7 +19,7 @@ module Constructor #:nodoc:#
         a_keys.delete(ck) # Delete inbound keys as we address them
       end
       if missing.size > 0 || a_keys.size > 0
-        raise ArgumentError.new(missing,a_keys)
+        raise ConstructorArgumentError.new(missing,a_keys)
       end
     end
     
@@ -37,7 +37,7 @@ module Constructor #:nodoc:#
   end
   
   # Fancy validation exception, based on missing and extraneous keys.
-  class ArgumentError < RuntimeError #:nodoc:#
+  class ConstructorArgumentError < RuntimeError #:nodoc:#
     def initialize(missing,rejected=[])
       err_msg = ''
       if missing.size > 0
@@ -45,10 +45,8 @@ module Constructor #:nodoc:#
       end
       if rejected.size > 0
         # Some inbound keys were not addressed earlier; this means they're unwanted
-        if err_msg
+        unless err_msg.empty?
           err_msg << "; " # Appending to earlier message about missing items
-        else
-          err_msg = ''
         end
         # Enumerate the rejected key names
         err_msg << "Rejected constructor args [#{rejected.join(',')}]"

--- a/spec/constructor_spec.rb
+++ b/spec/constructor_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.dirname(__FILE__) + '/../lib/constructor') 
+require File.expand_path('../lib/constructor', File.dirname(__FILE__))
 
 describe 'standard constructor usage' do
   it 'allows for object construction using a hash of named arguments' do

--- a/spec/constructor_spec.rb
+++ b/spec/constructor_spec.rb
@@ -209,12 +209,12 @@ describe 'stict mode usage' do
     # Omit foo
     lambda {
       TestingStrictArgsDefault.new :bar => 'ok,yeah'
-    }.should raise_error(Constructor::ArgumentError, /foo/)
+    }.should raise_error(Constructor::ConstructorArgumentError, /foo/)
     
     # Omit bar
     lambda {
       TestingStrictArgsDefault.new :foo => 'ok,yeah'
-    }.should raise_error(Constructor::ArgumentError, /bar/)
+    }.should raise_error(Constructor::ConstructorArgumentError, /bar/)
   end
 
   it 'defaults to strict argument enforcement' do
@@ -226,16 +226,16 @@ describe 'stict mode usage' do
   end
 
   it 'does not allow empty constructor arguments when strict option is true' do
-    lambda {TestingStrictArgs.new {}}.should raise_error(Constructor::ArgumentError,/foo,bar/)
-    lambda {TestingStrictArgs.new}.should raise_error(Constructor::ArgumentError,/foo,bar/)
-    lambda {TestingStrictArgs.new nil}.should raise_error(Constructor::ArgumentError,/foo,bar/)
+    lambda {TestingStrictArgs.new {}}.should raise_error(Constructor::ConstructorArgumentError,/foo,bar/)
+    lambda {TestingStrictArgs.new}.should raise_error(Constructor::ConstructorArgumentError,/foo,bar/)
+    lambda {TestingStrictArgs.new nil}.should raise_error(Constructor::ConstructorArgumentError,/foo,bar/)
   end
 
   it 'does not allow extraneous arguments when strict option is true' do
     [ /thing/, /other/ ].each do |rejected_arg|
       lambda {
         TestingStrictArgs.new(:foo => 1, :bar => 2, :other => 3, :thing => 4)
-      }.should raise_error(Constructor::ArgumentError, rejected_arg)
+      }.should raise_error(Constructor::ConstructorArgumentError, rejected_arg)
     end
   end
 
@@ -247,16 +247,16 @@ describe 'stict mode usage' do
     t2.bar.should eql(2)
 
     # See that strictness still applies
-    lambda {TestingStrictArgs2.new :no => 'good'}.should raise_error(Constructor::ArgumentError)
+    lambda {TestingStrictArgs2.new :no => 'good'}.should raise_error(Constructor::ConstructorArgumentError)
   end
 end
 
-describe 'catching Constructor::ArgumentError' do
+describe 'catching Constructor::ConstructorArgumentError' do
   it 'allows for generic rescuing of constructor argument errors' do
     begin
       TestingStrictArgs.new :broken => 'yoobetcha'
     rescue => bad_news
-      bad_news.should be_kind_of(Constructor::ArgumentError)
+      bad_news.should be_kind_of(Constructor::ConstructorArgumentError)
     end
   end
 end

--- a/spec/constructor_struct_spec.rb
+++ b/spec/constructor_struct_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../lib/constructor_struct'
+require File.expand_path('../lib/constructor_struct', File.dirname(__FILE__))
 
 describe ConstructorStruct, "#new" do
   def struct(*accessors)


### PR DESCRIPTION
If you do `raise ArgumentError, "Error message"` from within a class that uses the `constructor` class method, there is an unexpected problem:

```
undefined method `join' for "Error message":String
```

This is due to a name collision between the standard ArgumentError and Constructor::ArgumentError classes. The name collision occurs because the `constructor` class method includes the Constructor module into the class that calls `constructor`, thus shadowing the standard ArgumentError class.

Although it is possible to work around this issue by using `raise ::ArgumentError`, I think users of the constructor library should not be expected to do that, especially because the Constructor::ArgumentError class is explicitly hidden from the library documentation.

My patch renames Constructor::ArgumentError to Constructor::ConstructorArgumentError. This might affect users who are explicitly trying to rescue Constructor::ArgumentError. But, I suspect that very few, if any, users are doing that.
